### PR TITLE
added redirect web-course and deleted spare course-card  

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -28,4 +28,6 @@
 /school-management/ https://courses.ed-era.com/courses/course-v1:EDERA-PROSVITCENTER+SM101+sm101/about
 /effective-communication/ https://courses.ed-era.com/courses/course-v1:EDERA-SMARTOSVITA+EC101+EC101/about
 /budget-basics/ https://courses.ed-era.com/courses/course-v1:EDERA-IRF+BP101+bp101/about
+/budget-basics/ https://courses.ed-era.com/courses/course-v1:EDERA-IRF+BP101+bp101/about
+/web/ https://courses.ed-era.com/courses/course-v1:EDERA_BBF+WEB+2019/about
 # EOF - do not leave any line (even empty) after this line!!!

--- a/templates/index.jade
+++ b/templates/index.jade
@@ -50,8 +50,8 @@ html
 				+course(locals.courses.effective_communication)
 				// Управління школою. Практикум
 				+course(locals.courses.prosvit)
-				// ДНК Лідерів
-				+course(locals.courses.leader_dna)
+				//- ДНК Лідерів
+				//-+course(locals.courses.leader_dna)
 				// Інтерактивний журнал
 				+course(locals.courses.hrights_live)
 				//- Колошкільне дитинознавство


### PR DESCRIPTION
Preproduction version: https://stage.ed-era.com/

Please check that:
- the block "Всі курси" on main page contains 8 courses (2 rows)
- redirect for web-course (/web/)